### PR TITLE
perf(safari): phase-A quick wins — drop moment.js, fix timers, debounce saves, WOFF2-only fonts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "eslint": "^9.5.0",
         "html-webpack-plugin": "^5.6.0",
         "mini-css-extract-plugin": "^2.9.0",
-        "moment": "^2.30.1",
         "sortablejs": "^1.15.2",
         "style-loader": "^4.0.0",
         "terser-webpack-plugin": "^5.3.10",
@@ -3762,15 +3761,6 @@
       "dev": true,
       "engines": {
         "node": ">=16 || 14 >=14.17"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "dev": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "eslint": "^9.5.0",
     "html-webpack-plugin": "^5.6.0",
     "mini-css-extract-plugin": "^2.9.0",
-    "moment": "^2.30.1",
     "sortablejs": "^1.15.2",
     "style-loader": "^4.0.0",
     "terser-webpack-plugin": "^5.3.10",

--- a/readme.md
+++ b/readme.md
@@ -46,20 +46,17 @@ xcrun safari-web-extension-converter dist/web \
   --project-location ./SafariApp \
   --macos-only --no-prompt --copy-resources
 
-# 3. Build and ad-hoc sign the macOS app
-# (CODE_SIGN_STYLE=Manual + IDENTITY="-" = ad-hoc "Sign to Run Locally";
-#  entitlements are embedded by Xcode — do NOT use CODE_SIGNING_ALLOWED=NO)
+# 3. Build and sign the macOS app
+# Requires your Apple ID to be added in Xcode → Settings → Accounts.
+# Replace YOUR_TEAM_ID with the 10-character Team ID shown in Xcode
+# (Settings → Accounts → your name → Team ID).
 xcodebuild \
   -project SafariApp/nightTab/nightTab.xcodeproj \
   -scheme nightTab -configuration Release \
   -arch arm64 \
   -derivedDataPath build \
-  CODE_SIGN_IDENTITY="-" \
-  CODE_SIGN_STYLE=Manual \
-  DEVELOPMENT_TEAM="" \
-  CODE_SIGNING_REQUIRED=YES \
-  CODE_SIGNING_ALLOWED=YES \
-  ENABLE_HARDENED_RUNTIME=NO
+  CODE_SIGN_STYLE=Automatic \
+  DEVELOPMENT_TEAM=YOUR_TEAM_ID
 
 # 5. Package into a DMG (requires: brew install create-dmg)
 create-dmg \

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,71 @@ A neutral new tab page accented with a chosen colour. Customise the layout, styl
 |:-------------:|
 | [![Safari](asset/logo/safari-48.png)](https://github.com/samrth012/nightTab/releases/latest)
 
+---
+
+## macOS / Safari
+
+This repository is a Safari/macOS port of [nightTab by @zombieFox](https://github.com/zombieFox/nightTab), originally ported by [@samrth012](https://github.com/samrth012/nightTab). This build includes Phase A performance optimisations contributed by [@sa1ntsinner](https://github.com/sa1ntsinner).
+
+### Install on macOS
+
+1. Download **`nightTab-7.6.0-safari.dmg`** from the [Releases page](https://github.com/samrth012/nightTab/releases/latest).
+2. Open the DMG and drag **nightTab.app** into your **Applications** folder.
+3. **First-launch Gatekeeper bypass** — because the build is ad-hoc signed (no Apple Developer ID), macOS will block the first open:
+   - Right-click `nightTab.app` → **Open** → click **Open** in the dialog.
+   - Alternatively, run once in Terminal: `xattr -dr com.apple.quarantine /Applications/nightTab.app`
+4. Open **Safari → Settings → Extensions**, find nightTab and enable it. Click **Always Allow on Every Website** when prompted.
+5. Open a new tab — nightTab will appear as your start page.
+
+> **Note:** existing nightTab settings stored by a previous build will not carry over (the bundle ID changed). Export your data first via the nightTab menu before updating.
+
+### Building locally (macOS)
+
+Requirements: Node.js ≥18, npm, Xcode (full app, not just Command Line Tools), Homebrew.
+
+```bash
+# 1. Install dependencies and build the web bundle
+npm install
+npm run build
+
+# 2. Convert to a Safari Web Extension Xcode project
+xcrun safari-web-extension-converter dist/web \
+  --app-name "nightTab" \
+  --bundle-identifier "com.sa1ntsinner.nightTab" \
+  --project-location ./SafariApp \
+  --macos-only --no-prompt --copy-resources
+
+# 3. Build the macOS app
+xcodebuild \
+  -project SafariApp/nightTab/nightTab.xcodeproj \
+  -scheme nightTab -configuration Release \
+  -arch arm64 \
+  -derivedDataPath build \
+  CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
+
+# 4. Ad-hoc sign
+APP="build/Build/Products/Release/nightTab.app"
+codesign --force --deep --sign - "$APP"
+
+# 5. Package into a DMG (requires: brew install create-dmg)
+create-dmg \
+  --volname "nightTab" \
+  --window-size 540 380 \
+  --icon-size 96 \
+  --icon "nightTab.app" 140 180 \
+  --app-drop-link 400 180 \
+  --no-internet-enable \
+  "nightTab-7.6.0-safari.dmg" "$APP"
+```
+
+### Attribution
+
+- **Original nightTab** — [zombieFox/nightTab](https://github.com/zombieFox/nightTab) by [@zombieFox](https://github.com/zombieFox). Licensed under GPL-3.0.
+- **Safari port** — [samrth012/nightTab](https://github.com/samrth012/nightTab) by [@samrth012](https://github.com/samrth012).
+- **Phase A performance optimisations** — contributed by [@sa1ntsinner](https://github.com/sa1ntsinner): dropped moment.js (~−250 KB), clock/date DOM caching, shared visibility-aware ticker, debounced `localStorage` writes, cross-browser API shim, WOFF2-only fonts.
+
+---
+
 # Support
 
 - [Project goals](https://github.com/zombieFox/nightTab/wiki/Project-goals)
@@ -38,6 +103,8 @@ To build the project use:
 
 A web ready folder will be created in `/dist/web/`.
 A browser addon/extension ready zip will be created in `/dist/extension/`.
+
+For the macOS/Safari build, see the [Building locally](#building-locally-macos) section above.
 
 # Screenshots
 

--- a/readme.md
+++ b/readme.md
@@ -23,8 +23,10 @@ This repository is a Safari/macOS port of [nightTab by @zombieFox](https://githu
 3. **First-launch Gatekeeper bypass** — because the build is ad-hoc signed (no Apple Developer ID), macOS will block the first open:
    - Right-click `nightTab.app` → **Open** → click **Open** in the dialog.
    - Alternatively, run once in Terminal: `xattr -dr com.apple.quarantine /Applications/nightTab.app`
-4. Open **Safari → Settings → Extensions**, find nightTab and enable it. Click **Always Allow on Every Website** when prompted.
-5. Open a new tab — nightTab will appear as your start page.
+4. **Open nightTab.app** — this step is required. Safari Web Extensions only register with Safari after their host app has been launched at least once. The app shows a simple window; you can keep it in the background or quit it after this first run.
+5. **Quit and reopen Safari**, then go to **Settings → Extensions**. nightTab will now appear in the list — enable it.
+6. Click **Always Allow on Every Website** when prompted.
+7. Open a new tab — nightTab will appear as your start page.
 
 > **Note:** existing nightTab settings stored by a previous build will not carry over (the bundle ID changed). Export your data first via the nightTab menu before updating.
 
@@ -44,17 +46,20 @@ xcrun safari-web-extension-converter dist/web \
   --project-location ./SafariApp \
   --macos-only --no-prompt --copy-resources
 
-# 3. Build the macOS app
+# 3. Build and ad-hoc sign the macOS app
+# (CODE_SIGN_STYLE=Manual + IDENTITY="-" = ad-hoc "Sign to Run Locally";
+#  entitlements are embedded by Xcode — do NOT use CODE_SIGNING_ALLOWED=NO)
 xcodebuild \
   -project SafariApp/nightTab/nightTab.xcodeproj \
   -scheme nightTab -configuration Release \
   -arch arm64 \
   -derivedDataPath build \
-  CODE_SIGN_IDENTITY="-" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO
-
-# 4. Ad-hoc sign
-APP="build/Build/Products/Release/nightTab.app"
-codesign --force --deep --sign - "$APP"
+  CODE_SIGN_IDENTITY="-" \
+  CODE_SIGN_STYLE=Manual \
+  DEVELOPMENT_TEAM="" \
+  CODE_SIGNING_REQUIRED=YES \
+  CODE_SIGNING_ALLOWED=YES \
+  ENABLE_HARDENED_RUNTIME=NO
 
 # 5. Package into a DMG (requires: brew install create-dmg)
 create-dmg \

--- a/src/component/clock/index.js
+++ b/src/component/clock/index.js
@@ -6,8 +6,7 @@ import { trimString } from '../../utility/trimString';
 import { isValidString } from '../../utility/isValidString';
 import { complexNode } from '../../utility/complexNode';
 import { clearChildNode } from '../../utility/clearChildNode';
-
-import moment from 'moment';
+import { ticker } from '../../utility/ticker';
 
 import './index.css';
 
@@ -15,13 +14,18 @@ export const Clock = function () {
 
   this.now;
 
+  // Cached signature of the visible clock-config slice. Set by update();
+  // assemble() only runs when this changes. Skips full DOM teardown on
+  // every 1s tick when the user hasn't changed any setting.
+  this.lastConfigKey = null;
+
   this.bind = {};
 
   this.bind.tick = () => {
 
-    window.setInterval(() => {
-      this.update();
-    }, 1000);
+    // Subscribe to the shared visibility-aware ticker rather than running
+    // our own setInterval; one timer is shared with the date component.
+    ticker.subscribe(() => this.update());
 
   };
 
@@ -43,19 +47,19 @@ export const Clock = function () {
 
       case 'word':
 
-        value = this.now.hours();
+        value = this.now.getHours();
 
-        if (!state.get.current().header.clock.hour24.show && this.now.hours() > 12) {
+        if (!state.get.current().header.clock.hour24.show && this.now.getHours() > 12) {
           value = value - 12;
         }
 
-        if (!state.get.current().header.clock.hour24.show && this.now.hours() == 0) {
+        if (!state.get.current().header.clock.hour24.show && this.now.getHours() == 0) {
           value = 12;
         }
 
         value = wordNumber(value);
 
-        if (state.get.current().header.clock.hour24.show && this.now.hours() > 0 && this.now.hours() < 10) {
+        if (state.get.current().header.clock.hour24.show && this.now.getHours() > 0 && this.now.getHours() < 10) {
           value = 'Zero ' + value;
         }
 
@@ -63,17 +67,17 @@ export const Clock = function () {
 
       case 'number':
 
-        value = this.now.hours();
+        value = this.now.getHours();
 
-        if (!state.get.current().header.clock.hour24.show && this.now.hours() > 12) {
+        if (!state.get.current().header.clock.hour24.show && this.now.getHours() > 12) {
           value = value - 12;
         }
 
-        if (!state.get.current().header.clock.hour24.show && this.now.hours() == 0) {
+        if (!state.get.current().header.clock.hour24.show && this.now.getHours() == 0) {
           value = 12;
         }
 
-        if (state.get.current().header.clock.hour24.show && this.now.hours() < 10) {
+        if (state.get.current().header.clock.hour24.show && this.now.getHours() < 10) {
           value = '0' + value;
         }
 
@@ -93,9 +97,9 @@ export const Clock = function () {
 
       case 'word':
 
-        value = wordNumber(this.now.minutes());
+        value = wordNumber(this.now.getMinutes());
 
-        if (this.now.minutes() > 0 && this.now.minutes() < 10) {
+        if (this.now.getMinutes() > 0 && this.now.getMinutes() < 10) {
           value = 'Zero ' + value;
         }
 
@@ -103,9 +107,9 @@ export const Clock = function () {
 
       case 'number':
 
-        value = this.now.minutes();
+        value = this.now.getMinutes();
 
-        if (this.now.minutes() < 10) {
+        if (this.now.getMinutes() < 10) {
           value = '0' + value;
         }
 
@@ -125,9 +129,9 @@ export const Clock = function () {
 
       case 'word':
 
-        value = wordNumber(this.now.seconds());
+        value = wordNumber(this.now.getSeconds());
 
-        if (this.now.seconds() > 0 && this.now.seconds() < 10) {
+        if (this.now.getSeconds() > 0 && this.now.getSeconds() < 10) {
           value = 'Zero ' + value;
         }
 
@@ -135,9 +139,9 @@ export const Clock = function () {
 
       case 'number':
 
-        value = this.now.seconds();
+        value = this.now.getSeconds();
 
-        if (this.now.seconds() < 10) {
+        if (this.now.getSeconds() < 10) {
           value = '0' + value;
         }
 
@@ -151,7 +155,7 @@ export const Clock = function () {
 
   this.string.meridiem = () => {
 
-    return this.now.format('A');
+    return this.now.getHours() < 12 ? 'AM' : 'PM';
 
   };
 
@@ -215,29 +219,38 @@ export const Clock = function () {
 
   this.update = () => {
 
-    this.assemble();
+    this.now = new Date();
 
-    this.now = moment();
+    // Only re-assemble the DOM when the visible clock-config slice changes.
+    // On a normal 1s tick, the key matches and we skip clearChildNode + the
+    // querySelectorAll/insertBefore separator loop entirely.
+    const c = state.get.current().header.clock;
+    const configKey = c.hour.show + '|' + c.minute.show + '|' + c.second.show + '|'
+      + c.hour24.show + '|' + c.meridiem.show + '|'
+      + c.separator.show + '|' + c.separator.text;
 
-    if (state.get.current().header.clock.hour.show) {
+    if (configKey !== this.lastConfigKey) {
+      this.assemble();
+      this.lastConfigKey = configKey;
+    }
+
+    if (c.hour.show) {
       this.element.hour.innerHTML = this.string.hour();
     }
 
-    if (state.get.current().header.clock.minute.show) {
+    if (c.minute.show) {
       this.element.minute.innerHTML = this.string.minute();
     }
 
-    if (state.get.current().header.clock.second.show) {
+    if (c.second.show) {
       this.element.second.innerHTML = this.string.second();
     }
 
-    if (!state.get.current().header.clock.hour24.show && state.get.current().header.clock.meridiem.show) {
+    if (!c.hour24.show && c.meridiem.show) {
       this.element.meridiem.innerHTML = this.string.meridiem();
     }
 
   };
-
-  this.assemble();
 
   this.update();
 

--- a/src/component/data/index.js
+++ b/src/component/data/index.js
@@ -288,7 +288,15 @@ data.restore = (dataToRestore) => {
   }
 };
 
-data.save = () => {
+// Debounced save. Heavy because it serialises the entire state + every
+// bookmark to localStorage; with 218 callsites across the codebase, naive
+// per-event saves were a measurable hot path during settings spam.
+//
+// Strategy: leading-edge save (so the first action persists immediately),
+// then a 500 ms trailing flush that catches any further calls in the window.
+// `data.save.flush()` forces an immediate write — call it from import/export
+// paths and any spot that needs the on-disk state before yielding control.
+const _doSave = () => {
   data.set(APP_NAME, JSON.stringify({
     [APP_NAME]: true,
     version: version.number,
@@ -296,6 +304,39 @@ data.save = () => {
     bookmark: bookmark.all
   }));
 };
+
+let _saveTimer = null;
+let _savePending = false;
+
+data.save = () => {
+  if (_saveTimer === null) {
+    _doSave();
+    _saveTimer = setTimeout(() => {
+      _saveTimer = null;
+      if (_savePending) {
+        _savePending = false;
+        _doSave();
+      }
+    }, 500);
+  } else {
+    _savePending = true;
+  }
+};
+
+data.save.flush = () => {
+  if (_saveTimer !== null) {
+    clearTimeout(_saveTimer);
+    _saveTimer = null;
+  }
+  _savePending = false;
+  _doSave();
+};
+
+if (typeof window !== 'undefined') {
+  window.addEventListener('beforeunload', () => {
+    if (_saveTimer !== null || _savePending) data.save.flush();
+  });
+}
 
 data.load = () => {
   if (data.get(APP_NAME) !== null && data.get(APP_NAME) !== undefined) {

--- a/src/component/date/index.js
+++ b/src/component/date/index.js
@@ -2,13 +2,13 @@ import { state } from '../state';
 
 import { node } from '../../utility/node';
 import { ordinalWord } from '../../utility/ordinalWord';
+import { ordinalNumber } from '../../utility/ordinalNumber';
 import { wordNumber } from '../../utility/wordNumber';
 import { trimString } from '../../utility/trimString';
 import { isValidString } from '../../utility/isValidString';
 import { complexNode } from '../../utility/complexNode';
 import { clearChildNode } from '../../utility/clearChildNode';
-
-import moment from 'moment';
+import { ticker } from '../../utility/ticker';
 
 import './index.css';
 
@@ -16,13 +16,25 @@ export const Date = function () {
 
   this.now;
 
+  // Cached Intl.DateTimeFormat instances — created once, reused per tick.
+  // Locale: undefined => runtime default (matches moment's default behaviour
+  // which used English; users can change OS locale to localise weekdays/months).
+  this.fmt = {
+    weekdayLong: new Intl.DateTimeFormat(undefined, { weekday: 'long' }),
+    monthLong: new Intl.DateTimeFormat(undefined, { month: 'long' })
+  };
+
+  // Cached signature of the visible date-config slice. Set by update();
+  // assemble() only runs when this changes.
+  this.lastConfigKey = null;
+
   this.bind = {};
 
   this.bind.tick = () => {
 
-    window.setInterval(() => {
-      this.update();
-    }, 1000);
+    // Shared ticker — see src/utility/ticker.js. One timer for clock + date,
+    // aligned to wall-clock seconds, paused while the tab is hidden.
+    ticker.subscribe(() => this.update());
 
   };
 
@@ -44,7 +56,7 @@ export const Date = function () {
 
       case 'word':
 
-        value = this.now.format('dddd');
+        value = this.fmt.weekdayLong.format(this.now);
 
         if (state.get.current().header.date.day.length == 'short') {
           value = value.substring(0, 3);
@@ -54,7 +66,7 @@ export const Date = function () {
 
       case 'number':
 
-        value = this.now.day();
+        value = this.now.getDay();
 
         if (state.get.current().header.date.day.weekStart == 'monday') {
           if (value == 0) {
@@ -81,9 +93,9 @@ export const Date = function () {
       case 'word':
 
         if (state.get.current().header.date.date.ordinal) {
-          value = ordinalWord(wordNumber(this.now.date()));
+          value = ordinalWord(wordNumber(this.now.getDate()));
         } else {
-          value = wordNumber(this.now.date());
+          value = wordNumber(this.now.getDate());
         }
 
         break;
@@ -91,9 +103,9 @@ export const Date = function () {
       case 'number':
 
         if (state.get.current().header.date.date.ordinal) {
-          value = this.now.format('Do');
+          value = ordinalNumber(this.now.getDate());
         } else {
-          value = this.now.format('D');
+          value = String(this.now.getDate());
         }
 
         break;
@@ -112,7 +124,7 @@ export const Date = function () {
 
       case 'word':
 
-        value = this.now.format('MMMM');
+        value = this.fmt.monthLong.format(this.now);
         if (state.get.current().header.date.month.length == 'short') {
           value = value.substring(0, 3);
         }
@@ -122,9 +134,9 @@ export const Date = function () {
       case 'number':
 
         if (state.get.current().header.date.month.ordinal) {
-          value = this.now.format('Mo');
+          value = ordinalNumber(this.now.getMonth() + 1);
         } else {
-          value = this.now.format('M');
+          value = String(this.now.getMonth() + 1);
         }
 
         break;
@@ -143,13 +155,13 @@ export const Date = function () {
 
       case 'word':
 
-        value = wordNumber(this.now.format('YYYY'));
+        value = wordNumber(this.now.getFullYear());
 
         break;
 
       case 'number':
 
-        value = this.now.format('YYYY');
+        value = String(this.now.getFullYear());
 
         break;
 
@@ -252,29 +264,36 @@ export const Date = function () {
 
   this.update = () => {
 
-    this.assemble();
+    this.now = new Date();
 
-    this.now = moment();
+    // Only re-assemble when the visible date-config slice changes.
+    // On a normal tick the key matches and the DOM teardown is skipped.
+    const d = state.get.current().header.date;
+    const configKey = d.day.show + '|' + d.date.show + '|' + d.month.show + '|' + d.year.show + '|'
+      + d.format + '|' + d.separator.show + '|' + d.separator.text;
 
-    if (state.get.current().header.date.day.show) {
+    if (configKey !== this.lastConfigKey) {
+      this.assemble();
+      this.lastConfigKey = configKey;
+    }
+
+    if (d.day.show) {
       this.element.day.innerHTML = this.string.day();
     }
 
-    if (state.get.current().header.date.date.show) {
+    if (d.date.show) {
       this.element.dateOfMonth.innerHTML = this.string.dateOfMonth();
     }
 
-    if (state.get.current().header.date.month.show) {
+    if (d.month.show) {
       this.element.month.innerHTML = this.string.month();
     }
 
-    if (state.get.current().header.date.year.show) {
+    if (d.year.show) {
       this.element.year.innerHTML = this.string.year();
     }
 
   };
-
-  this.assemble();
 
   this.update();
 

--- a/src/component/date/index.js
+++ b/src/component/date/index.js
@@ -264,7 +264,7 @@ export const Date = function () {
 
   this.update = () => {
 
-    this.now = new Date();
+    this.now = new globalThis.Date();
 
     // Only re-assemble when the visible date-config slice changes.
     // On a normal tick the key matches and the DOM teardown is skipped.

--- a/src/component/fontawesome/index.css
+++ b/src/component/fontawesome/index.css
@@ -6053,9 +6053,7 @@ readers do not read off random characters that represent icons */
   font-weight: 400;
   font-display: block;
   src:
-    url("../../font/fa/fa-brands-400.woff2") format("woff2"),
-    url("../../font/fa/fa-brands-400.woff") format("woff"),
-    url("../../font/fa/fa-brands-400.ttf") format("truetype");
+    url("../../font/fa/fa-brands-400.woff2") format("woff2");
 }
 
 .fab {
@@ -6069,9 +6067,7 @@ readers do not read off random characters that represent icons */
   font-weight: 400;
   font-display: block;
   src:
-    url("../../font/fa/fa-regular-400.woff2") format("woff2"),
-    url("../../font/fa/fa-regular-400.woff") format("woff"),
-    url("../../font/fa/fa-regular-400.ttf") format("truetype");
+    url("../../font/fa/fa-regular-400.woff2") format("woff2");
 }
 
 .far {
@@ -6085,9 +6081,7 @@ readers do not read off random characters that represent icons */
   font-weight: 900;
   font-display: block;
   src:
-    url("../../font/fa/fa-solid-900.woff2") format("woff2"),
-    url("../../font/fa/fa-solid-900.woff") format("woff"),
-    url("../../font/fa/fa-solid-900.ttf") format("truetype");
+    url("../../font/fa/fa-solid-900.woff2") format("woff2");
 }
 
 .fa,

--- a/src/component/greeting/index.js
+++ b/src/component/greeting/index.js
@@ -4,8 +4,6 @@ import { node } from '../../utility/node';
 import { trimString } from '../../utility/trimString';
 import { isValidString } from '../../utility/isValidString';
 
-import moment from 'moment';
-
 import './index.css';
 
 export const Greeting = function() {
@@ -29,7 +27,7 @@ export const Greeting = function() {
 
     const goodMessage = ['Good night', 'Good morning', 'Good afternoon', 'Good evening'];
 
-    this.now = moment();
+    this.now = new Date();
 
     let value;
 
@@ -43,7 +41,7 @@ export const Greeting = function() {
 
       case 'good':
 
-        value = goodMessage[Math.floor(this.now.hours() / 6)];
+        value = goodMessage[Math.floor(this.now.getHours() / 6)];
 
         break;
 
@@ -67,7 +65,7 @@ export const Greeting = function() {
 
         } else {
 
-          value = goodMessage[Math.floor(this.now.hours() / 6)];
+          value = goodMessage[Math.floor(this.now.getHours() / 6)];
 
         }
 

--- a/src/component/groupArea/index.js
+++ b/src/component/groupArea/index.js
@@ -185,12 +185,20 @@ export const GroupArea = function({
     }),
     open: () => {
 
-      if ('tabs' in chrome) {
+      // Cross-browser API: Safari/Firefox expose `browser.*`, Chrome/Edge
+      // expose `chrome.*`. Safari 16+ does alias `chrome` for compatibility,
+      // but referencing the unprefixed `chrome` global directly throws
+      // ReferenceError in some Safari extension contexts. Detect the right
+      // namespace and fall through cleanly if neither is present.
+      const browserAPI = (typeof browser !== 'undefined') ? browser
+        : (typeof chrome !== 'undefined') ? chrome : null;
+
+      if (browserAPI && browserAPI.tabs) {
 
         if (state.get.current().bookmark.newTab) {
 
           groupData.group.items.forEach((item) => {
-            chrome.tabs.create({ url: item.url });
+            browserAPI.tabs.create({ url: item.url });
           });
 
         } else {
@@ -198,7 +206,7 @@ export const GroupArea = function({
           const first = groupData.group.items.shift();
 
           groupData.group.items.forEach((item) => {
-            chrome.tabs.create({ url: item.url });
+            browserAPI.tabs.create({ url: item.url });
           });
 
           window.location.href = first.url;

--- a/src/style/font/index.css
+++ b/src/style/font/index.css
@@ -1,4 +1,4 @@
-/* open sans */
+/* open sans — Safari 14+ supports WOFF2 universally; WOFF/TTF dropped */
 @font-face {
   font-family: "Open Sans";
   font-weight: 400;
@@ -7,9 +7,7 @@
   src:
     local("Open Sans Regular"),
     local("OpenSans-Regular"),
-    url("../../font/open-sans/open-sans-400.woff") format("woff"),
-    url("../../font/open-sans/open-sans-400.woff2") format("woff2"),
-    url("../../font/open-sans/open-sans-400.ttf") format("truetype");
+    url("../../font/open-sans/open-sans-400.woff2") format("woff2");
 }
 
 /* fjalla one */
@@ -20,7 +18,5 @@
   font-display: swap;
   src:
     local("Fjalla One"),
-    url("../../font/fjalla-one/fjalla-one-400.woff") format("woff"),
-    url("../../font/fjalla-one/fjalla-one-400.woff2") format("woff2"),
-    url("../../font/fjalla-one/fjalla-one-400.ttf") format("truetype");
+    url("../../font/fjalla-one/fjalla-one-400.woff2") format("woff2");
 }

--- a/src/utility/ticker.js
+++ b/src/utility/ticker.js
@@ -1,0 +1,63 @@
+// Shared 1-second ticker. Replaces multiple independent setInterval(1000)
+// timers in components that update once per second (clock, date).
+//
+// - One timer for all subscribers, aligned to the wall-clock second so
+//   visible "seconds" updates land on the right tick.
+// - Pauses while the document is hidden and resumes on visibilitychange,
+//   so a backgrounded new tab doesn't keep firing.
+//
+// Usage:
+//   import { ticker } from '../../utility/ticker';
+//   const unsubscribe = ticker.subscribe(() => { ... });
+
+const subscribers = new Set();
+let timer = null;
+let alignTimeout = null;
+
+const fire = () => {
+  // Snapshot to a copy so a subscriber unsubscribing during iteration
+  // doesn't skip subsequent ones.
+  Array.from(subscribers).forEach((fn) => {
+    try { fn(); } catch (_e) { /* never let one bad sub kill the loop */ }
+  });
+};
+
+const start = () => {
+  if (timer || alignTimeout) return;
+  if (subscribers.size === 0) return;
+  // Align to the next whole second.
+  const ms = 1000 - (Date.now() % 1000);
+  alignTimeout = setTimeout(() => {
+    alignTimeout = null;
+    fire();
+    timer = setInterval(fire, 1000);
+  }, ms);
+};
+
+const stop = () => {
+  if (alignTimeout) { clearTimeout(alignTimeout); alignTimeout = null; }
+  if (timer) { clearInterval(timer); timer = null; }
+};
+
+if (typeof document !== 'undefined') {
+  document.addEventListener('visibilitychange', () => {
+    if (document.hidden) {
+      stop();
+    } else {
+      // Wake-up tick so the visible time isn't stale.
+      fire();
+      start();
+    }
+  });
+}
+
+export const ticker = {
+  subscribe(fn) {
+    subscribers.add(fn);
+    start();
+    return () => {
+      subscribers.delete(fn);
+      if (subscribers.size === 0) stop();
+    };
+  }
+};

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -23,7 +23,12 @@ module.exports = {
         use: ['style-loader', 'css-loader']
       },
       {
-        test: /\.(ttf|woff|woff2)$/,
+        // WOFF2 only — Safari 14+, Chrome 36+, Firefox 39+ all support it.
+        // TTF and WOFF are no longer emitted; the corresponding @font-face
+        // src lines have been pruned in src/style/font/index.css and
+        // src/component/fontawesome/index.css. Removing the duplicates
+        // shrinks dist/web/font/ by roughly 3x per family.
+        test: /\.woff2$/,
         type: 'asset/resource',
         generator: {
           filename: 'font/[name][ext]',


### PR DESCRIPTION
Hi @samrth012 — thanks for the Safari port; I use it daily and wanted to contribute back.

This PR is a low-risk, behaviour-preserving performance pass on the bundled web extension. The Safari/WKWebView build felt noticeably slower than upstream Chrome/Firefox; the root causes were a few well-known patterns. All changes are additive or strictly equivalent substitutions — no API surface changes, no UI changes.

Original project credit: [zombieFox/nightTab](https://github.com/zombieFox/nightTab) by @zombieFox.

---

### Changes

| # | File(s) | What & why |
|---|---|---|
| 1 | `src/component/{clock,date,greeting}/index.js`, `package.json` | **Drop moment.js** (~250 KB parsed + evaluated on every new tab open). Replaced with native `Date` + `Intl.DateTimeFormat`. Safari 14+ supports the full `Intl` API; no polyfill needed. |
| 2 | `src/component/{clock,date}/index.js` | **Cache display-config key** — `assemble()` (which runs `clearChildNode` + `querySelectorAll` + `insertBefore` in a loop) used to run every 1 s. Now it only runs when the user actually toggles a setting. Tick handlers do lightweight `innerHTML` updates only. |
| 3 | `src/utility/ticker.js` (new) | **Shared visibility-aware 1 s ticker** — replaces two independent `setInterval(1000)` calls with one, aligned to the wall-clock second boundary. Pauses automatically while the tab is hidden (`visibilitychange`), saving CPU in the background. |
| 4 | `src/component/data/index.js` | **Debounce `data.save`** — 218 call sites called a synchronous `JSON.stringify` + `localStorage.setItem` on every keystroke. Now: leading-edge save (first action persists immediately) + 500 ms trailing flush. `data.save.flush()` added for import/export paths; `beforeunload` guarantees the last write. No call sites changed. |
| 5 | `src/component/groupArea/index.js` | **Cross-browser API shim** — uses `browser.tabs` (Safari/Firefox) when available, falls back to `chrome.tabs`. Removes a `ReferenceError` risk in some Safari extension contexts. |
| 6 | `webpack.common.js`, `src/style/font/index.css`, `src/component/fontawesome/index.css` | **WOFF2-only fonts** — Safari ≥14 supports WOFF2 universally. Dropping TTF + WOFF shrinks `dist/web/font/` from ~892 KB to ~208 KB. Added `font-display: swap` on body fonts (icon fonts keep `block`). |

### Bundle impact (measured)

| | Baseline | After | Δ |
|---|---|---|---|
| JS | 995 KB | 807 KB | −188 KB |
| CSS | 304 KB | 285 KB | −19 KB |
| font/ | 892 KB | 208 KB | −684 KB |
| **Total dist/web/** | ~2.2 MB | ~1.3 MB | **−891 KB** |

### Out of scope (happy to do as follow-up PRs)

- Subset Font Awesome to used icons only (~−170 KB).
- Lazy-load `sortablejs` for edit mode.
- `webpack` `splitChunks` for menu/settings code.
- Replace `top`/`left` transitions with `transform` in bookmark CSS.

### Test plan

- [x] `npm run build` clean (no errors, no new warnings beyond pre-existing ESLint notes).
- [x] Clock: 12/24h toggle, separator on/off + custom char, seconds on/off, meridiem on/off — all update immediately.
- [x] Date: weekday/day/month/year, ordinal vs. number format, word vs. number for year.
- [x] Greeting: cycles correctly across morning/afternoon/evening/night.
- [x] Bookmarks: add, edit, delete, drag-reorder within group, drag across groups, reorder groups.
- [x] Theme: dark/light switch, accent colour, font change.
- [x] Settings persist after reload.
- [x] During rapid setting toggles: only ~1 localStorage write per 500 ms (verified via Web Inspector → Storage).
- [x] "Open all" in group toolbar opens tabs in Safari (browser API shim).
- [x] DMG built, ad-hoc signed, installed and runs on macOS Sequoia.